### PR TITLE
added dynamic versioning for hatch, removed the one for setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,5 +30,5 @@ dev = [
 [project.urls]
 repository = "https://github.com/neulab/llments"
 
-[tool.setuptools.dynamic]
-version = {attr = "llments.version.VERSION"}
+[tool.hatch.version]
+path = "llments/version.py"


### PR DESCRIPTION
I found the hatch version of dynamic version-tracking and removed the lines for setuptools.