### PR TITLE
ignore ipynb docstring errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,6 @@ select = ["D"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.ruff.lint.per-file-ignores]
+"*.ipynb" = ["D103", "D200", "D212"]


### PR DESCRIPTION
## Description

Ignore ruff docstring errors in ipynb files

## References

- Fixes #64 
